### PR TITLE
Fix abort on dt_change_max for single precision

### DIFF
--- a/src/setup/init.cpp
+++ b/src/setup/init.cpp
@@ -57,8 +57,8 @@ void incflo::ReadParameters ()
 
         // This limits dt growth per time step
         pp.query("dt_change_max", m_dt_change_max);
-        if ( m_dt_change_max < 1.0 || m_dt_change_max > 1.1 ) {
-            amrex::Abort("We require 1. < dt_change_max <= 1.1");
+        if ( m_dt_change_max < 1.0_rt || m_dt_change_max > 1.1_rt ) {
+            amrex::Abort("We require 1. <= dt_change_max <= 1.1");
         }
 
         // Physics


### PR DESCRIPTION
Without this change, incflo aborts for many inputs in single precision with:

```
MPI initialized with 1 MPI processes
MPI initialized with thread support level 0
AMReX (26.09-13-g9878e5e01332-dirty) initialized
incflo git hash: 20.08-376-g46de336
amrex::Abort::0::We require 1. < dt_change_max <= 1.1 !!!
SIGABRT
See Backtrace.0 file for details
```

I have also changed the `<` to `<=` on the lower bound of the message to be consistent with the actual behavior. 