### PR TITLE
Restore option to check tracer conservation

### DIFF
--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -86,12 +86,12 @@ void incflo::Advance()
     particleData.Redistribute();
 #endif
 
-    // // This sums over all levels
-    // if (m_test_tracer_conservation) {
-    //     Real sum = volumeWeightedSum(get_tracer_new_const(),0,geom,ref_ratio);
-    //     amrex::Print() << "Sum tracer volume wgt2 = " << m_cur_time+m_dt << " " <<
-    //                        sum << "\n";
-    // }
+    // This sums over all levels
+    if (m_test_tracer_conservation) {
+        Real sum = amrex::volumeWeightedSum(get_tracer_new_const(), 0, Geom(), refRatio());
+        amrex::Print() << "Sum tracer volume wgt = " << m_cur_time+m_dt << " " <<
+            sum << "\n";
+    }
 
     // Stop timing current time step
     Real end_step = static_cast<Real>(ParallelDescriptor::second()) - strt_step;


### PR DESCRIPTION
This was commented out, but several checked-in inputs files still use it. 